### PR TITLE
multiple definition of `lineFeed' & imageEnd

### DIFF
--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -8,9 +8,6 @@
 
 #include "common.h"
 
-const uint8_t lineFeed;
-const uint8_t imageEnd;
-
 typedef struct __attribute__((__packed__)) _bitmap
 {
     uint8_t magicNumber[2];


### PR DESCRIPTION
Removing the multiple definition in bitmap.h file allows the COMPILE.sh file to run without any error.