### PR TITLE
Improve compatibility with Windows bitmaps

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -381,6 +381,28 @@ int RLEDecompression(FILE *ptrIn, FILE *ptrOut)
                 total++;
             }
         }
+	else if (couples[1] >= 3)
+        {
+            /* Absolute sequence */
+            lecture = fread(&data[total], 1, couples[1], ptrIn);
+            if (lecture != couples[1])
+            {
+                fprintf(stderr, "Error while reading input data\n");
+                ok = false;
+                goto cleaning;
+            }
+            total += lecture;
+            /* Ensure file pointer is word-aligned */
+            if (couples[1] & 1)
+            {
+                fseek(ptrIn, +1, SEEK_CUR);
+            }
+        }
+	else if (couples[1] == 1)
+        {
+            /* End of frame */
+            break;
+        }
     }
     /* ------- */
 

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -103,6 +103,13 @@ int RLECompression(FILE *ptrIn, FILE *ptrOut)
     }
     /* ------- */
 
+    /* Ensuring correct image size */
+    if (!image->imageSize)
+    {
+        image->imageSize = image->width * image->height * image->depth / 8;
+    }
+    /* ------- */
+
     printHeader(image);
 
     /* Skipping data from the beginning to the start offset */


### PR DESCRIPTION
Hello! These are a couple of enhancements I made while using this to test out RLE bitmaps produced by my Windows 3.1 GDI driver.

The first change is to handle compression of DIBs that don't have the image size field filled out in the bitmap header. Windows drivers can produce and consume DIBs with this field set to zero, in which case the size is inferred from the width, height and depth, so I implemented this behaviour here.

The second is to handle decompression of RLE bitmaps that contain absolute (i.e. uncompressed) sequences. This tool doesn't produce such sequences, but being able to consume them is needed to handle bitmaps from other sources.

This doesn't cover "skip" sequences which allow the decoding to move around the frame, so decompressing bitmaps containing those will probably still crash the tool, but I think most cases are covered without that…